### PR TITLE
Fixed forbidden response in time series (stock) demo

### DIFF
--- a/src/RNANews/RNANewsConnector.ts
+++ b/src/RNANews/RNANewsConnector.ts
@@ -149,7 +149,7 @@ export class RNANewsConnector extends MorningstarConnector {
         }
 
         const api = this.api = this.api || new MorningstarAPI(options.api);
-        const url = new MorningstarURL('timeseries/rna-news', api.baseURL);
+        const url = new MorningstarURL('/ecint/v1/timeseries/rna-news', api.baseURL);
 
         url.setSecuritiesOptions([security]);
 

--- a/src/Shared/MorningstarAPI.ts
+++ b/src/Shared/MorningstarAPI.ts
@@ -57,8 +57,6 @@ export class MorningstarAPI {
             window.location.href
         );
 
-        this.baseURL.pathname = '/ecint/v1/';
-
         if (this.baseURL.protocol !== 'https:') {
             throw new Error('Insecure API protocol');
         }

--- a/src/TimeSeries/TimeSeriesConnector.ts
+++ b/src/TimeSeries/TimeSeriesConnector.ts
@@ -138,7 +138,7 @@ export class TimeSeriesConnector extends MorningstarConnector {
         }
 
         const api = this.api = this.api || new MorningstarAPI(options.api);
-        const url = new MorningstarURL(this.path, api.baseURL);
+        const url = new MorningstarURL('/ecint/v1/' + this.path, api.baseURL);
 
         url.setSecuritiesOptions(securities);
 

--- a/test/unit-tests/runtime.ts
+++ b/test/unit-tests/runtime.ts
@@ -41,7 +41,7 @@ import * as JSDOM from 'jsdom';
 
 function getAPIOptions (): Shared.MorningstarAPIOptions {
     const apiOptions: Shared.MorningstarAPIOptions = {
-        url: 'https://www.emea-api.morningstar.com/ecint/v1/'
+        url: 'https://www.emea-api.morningstar.com'
     };
 
     if (FSSync.existsSync('.env')) {


### PR DESCRIPTION
Fetch called to incorrect url.

Pathname was `/timeseries/dividend`, but should be `ecint/v1/timeseries/dividend`.

![Screenshot 2024-08-16 at 13 40 22](https://github.com/user-attachments/assets/d0e7fcd1-3864-4944-a825-5f68dac59837)

## Notes

- Unit test succeeded because custom API options were provided in test which supplied the correct url with the base path.

![Screenshot 2024-08-16 at 13 51 39](https://github.com/user-attachments/assets/e5bab739-b347-4e55-ada0-1fe00da96443)
In *test/unit-tests/runtime.ts*