### PR TITLE
Added allowance for encoding info in content type.

### DIFF
--- a/src/Shared/MorningstarAPI.ts
+++ b/src/Shared/MorningstarAPI.ts
@@ -156,7 +156,7 @@ export class MorningstarAPI {
 
         const contentType = response.headers.get('Content-Type');
 
-        if (contentType !== 'application/json') {
+        if (!contentType?.startsWith('application/json')) {
             throw new Error(`Unexpected data: ${contentType}`);
         }
 


### PR DESCRIPTION
Testing the coming demo-live-data proxy resulted in `Error: Unexpected data: application/json; charset=utf-8`