### PR TITLE
Changed “value” to “volume” in OHLCV.

### DIFF
--- a/docs/connectors/morningstar/time-series/ohlcv.md
+++ b/docs/connectors/morningstar/time-series/ohlcv.md
@@ -2,7 +2,7 @@
 
  This type yields OHLCV time series data for a single or multiple securities.
 
- Returns Open, High, Low, Close, Value for the securities specified.
+ Returns Open, High, Low, Close, Volume for the securities specified.
 
  > **NOTE:** At the moment only a single security is supported.
 

--- a/src/TimeSeries/Converters/OHLCVSeriesConverter.ts
+++ b/src/TimeSeries/Converters/OHLCVSeriesConverter.ts
@@ -38,7 +38,7 @@ import MorningstarURL from '../../Shared/MorningstarURL';
 interface OHLCV {
     Id: string;
     Date: number;
-    Value: [open: number, high: number, low: number, close: number, value: number];
+    Value: [open: number, high: number, low: number, close: number, volume: number];
 }
 
 
@@ -127,7 +127,7 @@ export class OHLCVSeriesConverter extends TimeSeriesConverter {
 
         table.deleteColumns();
 
-        const valueColumns = ['Open', 'High', 'Low', 'Close', 'Value'];
+        const valueColumns = ['Open', 'High', 'Low', 'Close', 'Volume'];
 
         table.setColumn('Date');
 

--- a/src/TimeSeries/TimeSeriesJSON.ts
+++ b/src/TimeSeries/TimeSeriesJSON.ts
@@ -89,7 +89,7 @@ namespace TimeSeriesJSON {
         high: number,
         low: number,
         close: number,
-        value: number
+        volume: number
     ];
 
 

--- a/test/unit-tests/TimeSeries/OHLCV.test.ts
+++ b/test/unit-tests/TimeSeries/OHLCV.test.ts
@@ -45,7 +45,7 @@ export async function ohlcvLoad (
             `${securityId}_High`, 
             `${securityId}_Low`, 
             `${securityId}_Close`, 
-            `${securityId}_Value`
+            `${securityId}_Volume`
         ],
         'Connector table should exist of expected columns.'
     );


### PR DESCRIPTION
From Morningstar’s website, it looks like V stands for Volume in OHLCV.

<img width="1111" alt="Screenshot 2024-08-30 at 12 58 25" src="https://github.com/user-attachments/assets/b6e434f4-a2e4-4c07-b515-c67ac01308aa">
