### PR TITLE
Added metadata to RiskScoreConnector and improved demo

### DIFF
--- a/demos/dashboards-risk-score/demo.css
+++ b/demos/dashboards-risk-score/demo.css
@@ -31,10 +31,6 @@ body {
     border-bottom: none;
 }
 
-#dashboard-col-1 .highcharts-dashboards-component-title {
-    background-color: #336;
-}
-
 @media screen and (max-width: 1000px) {
     .row {
         flex-direction: column;

--- a/demos/dashboards-risk-score/demo.js
+++ b/demos/dashboards-risk-score/demo.js
@@ -1,30 +1,107 @@
 const loadingLabel = document.getElementById('loading-label');
 
 function displayRiskScore (postmanJSON) {
-    Dashboards.board('container', {
+
+    const highRiskRetirementPortfolio = {
+        name: 'HighRisk',
+        currency: 'USD',
+        totalValue: 100,
+        holdings: [
+            {
+                id: 'VTIAX',
+                idType: 'TradingSymbol',
+                weight: 33
+            },
+            {
+                id: 'POGRX',
+                idType: 'TradingSymbol',
+                weight: 20
+            },
+            {
+                id: 'OAKMX',
+                idType: 'TradingSymbol',
+                weight: 20
+            },
+            {
+                id: 'VEXAX',
+                idType: 'TradingSymbol',
+                weight: 15
+            },
+            {
+                id: 'OAKEX',
+                idType: 'TradingSymbol',
+                weight: 7
+            },
+            {
+                id: 'MWTRX',
+                idType: 'TradingSymbol',
+                weight: 5
+            }
+        ]
+    };
+
+    const lowRiskRetirementPortfolio = {
+        name: 'LowRisk',
+        currency: 'USD',
+        totalValue: 100,
+        holdings: [
+            {
+                id: 'VTIAX',
+                idType: 'TradingSymbol',
+                weight: 10
+            },
+            {
+                id: 'POGRX',
+                idType: 'TradingSymbol',
+                weight: 10
+            },
+            {
+                id: 'VDADX',
+                idType: 'TradingSymbol',
+                weight: 10
+            },
+            {
+                id: 'OAKMX',
+                idType: 'TradingSymbol',
+                weight: 10
+            },
+            {
+                id: 'VEXAX',
+                idType: 'TradingSymbol',
+                weight: 5
+            },
+            {
+                id: 'OAKEX',
+                idType: 'TradingSymbol',
+                weight: 5
+            },
+            {
+                id: 'MWTRX',
+                idType: 'TradingSymbol',
+                weight: 30
+            },
+            {
+                id: 'FSHBX',
+                idType: 'TradingSymbol',
+                weight: 10
+            },
+            {
+                id: 'VTAPX',
+                idType: 'TradingSymbol',
+                weight: 10
+            }
+        ]
+    }
+
+    const board = Dashboards.board('container', {
         dataPool: {
             connectors: [{
                 id: 'risk-score',
                 type: 'MorningstarRiskScore',
                 options: {
                     portfolios: [
-                        {
-                            name: 'TestPortfolio1',
-                            currency: 'USD',
-                            totalValue: 100,
-                            holdings: [
-                                {
-                                    id: 'F00000VCTT',
-                                    idType: 'SecurityID',
-                                    weight: 50
-                                },
-                                {
-                                    id: 'AAPL',
-                                    idType: 'TradingSymbol',
-                                    weight: 50
-                                }
-                            ]
-                        }
+                        lowRiskRetirementPortfolio,
+                        highRiskRetirementPortfolio
                     ],
                     postman: {
                         environmentJSON: postmanJSON
@@ -36,43 +113,91 @@ function displayRiskScore (postmanJSON) {
             {
                 renderTo: 'dashboard-col-0',
                 connector: {
-                    id: 'risk-score'
+                    id: 'risk-score',
+                    columnAssignment: [
+                        {
+                            seriesId: 'low-risk',
+                            data: ['LowRisk_RiskScore']
+                        },
+                        {
+                            seriesId: 'high-risk',
+                            data: ['HighRisk_RiskScore']
+                        }
+                    ]
+                },
+                type: 'Highcharts',
+                chartOptions: {
+                    chart: {
+                        animation: false,
+                        type: 'column'
+                    },
+                    credits: {
+                        enabled: false
+                    },
+                    title: {
+                        text: 'Risk score for each portfolio'
+                    },
+                    subtitle: {
+                        text: 'Conservative is a low risk portfolio,' + 
+                        'while Aggressive is a high risk portfolio'
+                    },
+                    yAxis: {
+                        title: {
+                            text: 'Risk Score'
+                        }
+                    },
+                    xAxis: {
+                        categories: ['Conservative', 'Aggressive']
+                    },
+                    series: [
+                        {
+                            id: 'low-risk',
+                            name: 'Conservative',
+                            tooltip: {
+                                headerFormat: 'Stock/Bond ratio: 50/50<br>',
+                                useHTML: true
+                            }
+                        },
+                        {
+                            id: 'high-risk',
+                            name: 'Aggressive',
+                            tooltip: {
+                                headerFormat: 'Stock/Bond ratio: 95/5<br>',
+                                useHTML: true
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                renderTo: 'dashboard-col-1',
+                connector: {
+                    id: 'risk-score',
+                    columnAssignment: [
+                        {
+                            seriesId: 'low-risk',
+                            data: ['LowRisk_RiskScore']
+                        },
+                        {
+                            seriesId: 'high-risk',
+                            data: ['HighRisk_RiskScore']
+                        }
+                    ]
                 },
                 type: 'DataGrid',
                 title: 'RiskScore',
                 dataGridOptions: {
-                    editable: false,
-                    columns: {
-                        'TestPortfolio1_EffectiveDate': {
-                            headerFormat: 'Date',
-                            cellFormatter: function () {
-                                return new Date(this.value)
-                                    .toISOString()
-                                    .substring(0, 10);
-                            }
-                        },
-                        'TestPortfolio1_RiskScore': {
-                            headerFormat: 'RiskScore'
-                        },
-                        'TestPortfolio1_AlignmentScore': {
-                            headerFormat: 'AlignmentScore'
-                        },
-                        'TestPortfolio1_RSquared': {
-                            headerFormat: 'RSquared'
-                        },
-                        'TestPortfolio1_RetainedWeightProxied': {
-                            headerFormat: 'RetainedWeight'
-                        },
-                        'TestPortfolio1_ScoringMethodUsed': {
-                            headerFormat: 'ScoringMethod'
-                        }
-                    }
+                    editable: false
                 }
             }
         ]
     });
-    
-    loadingLabel.style.display = 'none';
+
+    board.dataPool
+        .getConnectorTable('risk-score')
+        .then(() => {
+            loadingLabel.style.display = 'none';
+        });
 }
 
 async function handleSelectEnvironment (evt) {

--- a/demos/dashboards-risk-score/demo.js
+++ b/demos/dashboards-risk-score/demo.js
@@ -138,7 +138,7 @@ function displayRiskScore (postmanJSON) {
                         text: 'Risk score for each portfolio'
                     },
                     subtitle: {
-                        text: 'Conservative is a low risk portfolio,' + 
+                        text: 'Conservative is a low risk portfolio, ' + 
                         'while Aggressive is a high risk portfolio'
                     },
                     yAxis: {
@@ -172,22 +172,24 @@ function displayRiskScore (postmanJSON) {
             {
                 renderTo: 'dashboard-col-1',
                 connector: {
-                    id: 'risk-score',
-                    columnAssignment: [
-                        {
-                            seriesId: 'low-risk',
-                            data: ['LowRisk_RiskScore']
-                        },
-                        {
-                            seriesId: 'high-risk',
-                            data: ['HighRisk_RiskScore']
-                        }
-                    ]
+                    id: 'risk-score'
                 },
+                visibleColumns: [
+                    'LowRisk_RiskScore',
+                    'HighRisk_RiskScore'
+                ],
                 type: 'DataGrid',
                 title: 'RiskScore',
                 dataGridOptions: {
-                    editable: false
+                    editable: false,
+                    columns: {
+                        'LowRisk_RiskScore': {
+                            headerFormat: 'RiskScore, Conservative'
+                        },
+                        'HighRisk_RiskScore': {
+                            headerFormat: 'RiskScore, Aggressive'
+                        }
+                    }
                 }
             }
         ]

--- a/docs/connectors/morningstar/risk-score/risk-score.md
+++ b/docs/connectors/morningstar/risk-score/risk-score.md
@@ -10,19 +10,26 @@ Use the `RiskScoreConnector` to load risk scores.
 
 In dashboards, this connector is called `MorningstarRiskScore`.
 
-Specify the holdings in a portfolio in the options along with a postman environment
+Specify the portfolio holdings in the options along with a postman environment
 file for authentication, and other parameters such as `currency`.
 
 ### Holdings
 
-Holdings are the securities that make up the portfolio. You can specify a holding using different kinds of id’s. 
+Holdings are the securities that make up the portfolio. You can specify a 
+holding using different kinds of id’s. 
 
 Supported id-types are: `CUSIP`, `FundCode`, `ISIN`, `MSID`, `PerformanceId`,
  `SecurityID`, `TradingSymbol`.
 
-You can specify the quantity of this holding in the portfolio by using either `weight` or `value`. If you decide to use `weight`, you need to specify the `totalValue` of the portfolio.
+You can specify the quantity of this holding in the portfolio by using either 
+`weight` or `value`. If you decide to use `weight`, you need to specify 
+the `totalValue` of the portfolio.
 
-> **NOTE:** You cannot mix and match `weight` and `value`. Be consistent and stick to one.
+> **NOTE:** You cannot mix and match `weight` and `value`. 
+Be consistent and stick to one.
+
+If you specify any holdings that are invalid, the connector will still yield 
+a result. The invalid holdings are in the connector’s `metadata` after load.
 
 For more details, see [Morningstar’s RiskScore API].
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@highcharts/connectors-morningstar",
-    "version": "0.0.1-dev",
+    "version": "0.0.1-repository",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@highcharts/connectors-morningstar",
-            "version": "0.0.1-dev",
+            "version": "0.0.1-repository",
             "license": "UNLICENSED",
             "bin": {
                 "connectors-morningstar": "bin/morningstar-connectors.js"

--- a/src/RiskScore/RiskScoreConnector.ts
+++ b/src/RiskScore/RiskScoreConnector.ts
@@ -26,7 +26,7 @@ import External from '../Shared/External';
 import MorningstarConnector from '../Shared/MorningstarConnector';
 import MorningstarAPI from '../Shared/MorningstarAPI';
 import MorningstarURL from '../Shared/MorningstarURL';
-import RiskScoreOptions, { BaseRiskScorePortfolio, RiskScorePortfolio } from './RiskScoreOptions';
+import RiskScoreOptions, { BaseRiskScorePortfolio, RiskScoreMetadata, RiskScorePortfolio } from './RiskScoreOptions';
 import RiskScoreConverter from './RiskScoreConverter';
 import { HoldingIdentiferType, MorningstarHoldingOptions, MorningstarHoldingValueOptions, MorningstarHoldingWeightOptions } from '../Shared/MorningstarOptions';
 
@@ -197,6 +197,7 @@ export class RiskScoreConnector extends MorningstarConnector {
         super(options);
 
         this.converter = new RiskScoreConverter(options.converter);
+        this.metadata = this.converter.metadata;
         this.options = options;
     }
 
@@ -210,6 +211,10 @@ export class RiskScoreConnector extends MorningstarConnector {
 
     public override readonly converter: RiskScoreConverter;
 
+    /**
+     * Metadata from the previous load.
+     */
+    public override readonly metadata: RiskScoreMetadata;
 
     public override readonly options: RiskScoreOptions;
 

--- a/src/RiskScore/RiskScoreJSON.ts
+++ b/src/RiskScore/RiskScoreJSON.ts
@@ -14,6 +14,8 @@
 
 'use strict';
 
+import { RiskScoreInvalidHolding, RiskScoreMetadataMessage } from './RiskScoreOptions';
+
 
 /* *
  *
@@ -53,18 +55,6 @@ export namespace RiskScoreJSON {
 
     export type RiskScoreMetadataResponse = {
         messages: RiskScoreMetadataMessage[]
-    };
-
-    export type RiskScoreMetadataMessage = {
-        type: string,
-        message: string,
-        invalidHoldings: RiskScoreInvalidHolding[]
-    };
-
-    export type RiskScoreInvalidHolding = {
-        identifier: string,
-        identifierType: string,
-        status: string
     };
 
 

--- a/src/RiskScore/RiskScoreOptions.ts
+++ b/src/RiskScore/RiskScoreOptions.ts
@@ -19,7 +19,7 @@
  * */
 
 import { Currency } from '../Shared/LocalizationOptions';
-import MorningstarOptions, { MorningstarConverterOptions, MorningstarHoldingValueOptions, MorningstarHoldingWeightOptions } from '../Shared/MorningstarOptions';
+import MorningstarOptions, { MorningstarConverterOptions, MorningstarHoldingValueOptions, MorningstarHoldingWeightOptions, MorningstarMetadata } from '../Shared/MorningstarOptions';
 
 
 /* *
@@ -33,6 +33,22 @@ export interface RiskScoreConverterOptions extends MorningstarConverterOptions {
 
     // Nothing to add yet
 
+}
+
+export type RiskScoreMetadataMessage = {
+    type: string,
+    message: string,
+    invalidHoldings: RiskScoreInvalidHolding[]
+};
+
+export type RiskScoreInvalidHolding = {
+    identifier: string,
+    identifierType: string,
+    status: string
+};
+
+export interface RiskScoreMetadata extends MorningstarMetadata {
+    messages: RiskScoreMetadataMessage[]
 }
 
 export interface BaseRiskScorePortfolio {

--- a/src/Shared/External.ts
+++ b/src/Shared/External.ts
@@ -38,6 +38,9 @@ import _DataTable from '@highcharts/dashboards/es-modules/Data/DataTable';
  * */
 
 
+export type DataConnectorMetadata = _DataConnector['metadata'];
+
+
 export type DataConnectorOptions = Partial<_DataConnector.UserOptions>;
 
 

--- a/src/Shared/MorningstarOptions.ts
+++ b/src/Shared/MorningstarOptions.ts
@@ -129,6 +129,11 @@ export interface MorningstarHoldingValueOptions extends MorningstarHoldingOption
 }
 
 
+export interface MorningstarMetadata extends External.DataConnectorMetadata {
+    // Nothing to add yet
+}
+
+
 export interface MorningstarOptions extends External.DataConnectorOptions {
 
     /**

--- a/tests/RiskScore/RiskScore.test.ts
+++ b/tests/RiskScore/RiskScore.test.ts
@@ -59,6 +59,49 @@ export async function riskScoreLoad (
       );
 }
 
+export async function riskScoreLoadWithInvalidHoldings (
+    api: MC.Shared.MorningstarAPIOptions
+) {
+    const connector = new MC.RiskScoreConnector({
+        api,
+        portfolios: [
+            {
+                name: 'PortfolioWithInvalidHoldings',
+                currency: 'USD',
+                totalValue: 100,
+                holdings: [
+                    {
+                        id: 'F00000VCTT',
+                        idType: 'SecurityID',
+                        weight: 50
+                    },
+                    {
+                        id: 'AAPLL',
+                        idType: 'TradingSymbol',
+                        weight: 50
+                    }
+                ]
+            }
+        ]
+    });
+
+    await connector.load();
+
+    Assert.deepStrictEqual(
+        connector.metadata.messages,
+        [{
+            type: 'Warning',
+            message: 'Invalid or unentitled holdings',
+            invalidHoldings: [{
+                identifier: 'AAPLL',
+                identifierType: 'TradingSymbol',
+                status: 'Invalid'
+            }]
+        }]
+    );
+
+}
+
 export function riskScoreResponseValidation () {
     const exampleResponse = {
         'riskScores': [


### PR DESCRIPTION
- Added metadata to connector and converter. Messages from the API, including invalid holdings in the request are stored there after load.
- Updated demo to put risk scores into a chart

<img width="1659" alt="Screenshot 2024-09-26 at 09 19 16" src="https://github.com/user-attachments/assets/35b6d0b4-8836-45ba-98de-2c9f5dc6367e">
