### PR TITLE
Improved Investment Screener demo.

### DIFF
--- a/demos/dashboards-investment-screener/demo.js
+++ b/demos/dashboards-investment-screener/demo.js
@@ -10,16 +10,28 @@ function displayInvestmentScreener (postmanJSON) {
         'initialPurchase',
         'maxFrontEndLoad',
         'analystRatingScale',
-        'average12MonthCarbonRiskScore',
         'investmentType',
-        'holdingTypeId',
-        'universe'
+        'holdingTypeId'
     ];
+
+    const headerFormats = {
+        'secId': 'Security Id',
+        'tenforeId': 'Tenfore Id',
+        'name': 'Name',
+        'closePrice': 'Close Price',
+        'ongoingCharge': 'Annual Report Ongoing Charge',
+        'initialPurchase': 'Initial Purchase',
+        'maxFrontEndLoad': 'Maximum Front-End Load',
+        'analystRatingScale': 'Analyst Rating Scale',
+        'investmentType': 'Investment Type',
+        'holdingTypeId': 'Holding Type Id'
+    };
+
 
     const columns = secIds.map(id => ({
         id: `InvestmentScreener_${id}`,
         header: {
-            format: id
+            format: headerFormats[id] || id
         }
     }));
 
@@ -50,7 +62,6 @@ function displayInvestmentScreener (postmanJSON) {
                     id: 'investment-screener'
                 },
                 type: 'DataGrid',
-
                 dataGridOptions: {
                     editable: false,
                     columns


### PR DESCRIPTION
Improved Investment Screener demo.

_Internal note:_ Removed `average12MonthCarbonRiskScore` from data points as it doesn't return anything (might be related to the fact that it's labeled as Premium Data in the Morningstar dictionary).