### PR TITLE
Fixed XRay data table structure.

### DIFF
--- a/src/XRay/XRayConverter.ts
+++ b/src/XRay/XRayConverter.ts
@@ -222,8 +222,8 @@ export class XRayConverter extends MorningstarConverter {
         const table = this.table;
 
         for (const historicalPerformance of json) {
-            const periodRowId = `${benchmarkId}_${historicalPerformance.returnType}_TimePeriod`;
-            const valueRowId = `${benchmarkId}_${historicalPerformance.returnType}_Value`;
+            const periodRowId = `${benchmarkId}_${historicalPerformance.returnType}_${historicalPerformance.timePeriod}`;
+            const valueRowId = `${benchmarkId}_${historicalPerformance.returnType}_${historicalPerformance.timePeriod}_Value`;
 
             let rowIndex = 0;
 

--- a/tests/XRay/Breakdown.test.ts
+++ b/tests/XRay/Breakdown.test.ts
@@ -45,9 +45,7 @@ export async function breakdownLoad (
             'XRay_TotalReturn_M3',
             'XRay_TotalReturn_M3_Value',
             'XRay_TotalReturn_M12',
-            'XRay_TotalReturn_M12_Value',
-            'XRay_TotalReturn_TimePeriod',
-            'XRay_TotalReturn_Value'
+            'XRay_TotalReturn_M12_Value'
         ],
         'Connector table should exist of expected columns.'
     );

--- a/tests/XRay/Breakdown.test.ts
+++ b/tests/XRay/Breakdown.test.ts
@@ -39,7 +39,16 @@ export async function breakdownLoad (
 
     Assert.deepStrictEqual(
         connector.table.getColumnNames(),
-        ['XRay_TotalReturn_TimePeriod', 'XRay_TotalReturn_Value'],
+        [
+            'XRay_TotalReturn_M1',
+            'XRay_TotalReturn_M1_Value',
+            'XRay_TotalReturn_M3',
+            'XRay_TotalReturn_M3_Value',
+            'XRay_TotalReturn_M12',
+            'XRay_TotalReturn_M12_Value',
+            'XRay_TotalReturn_TimePeriod',
+            'XRay_TotalReturn_Value'
+        ],
         'Connector table should exist of expected columns.'
     );
 


### PR DESCRIPTION
Fixed #64, XRay data structure didn't include `timePeriod` which resulted in merging all of the data in one column.

**Changelog note:** Column name `XRay_TotalReturn_TimePeriod` is now changed to `XRay_TotalReturn_M1` and `XRay_TotalReturn_Value` is changed to `XRay_TotalReturn_M1_Value`. Where `M1` is used, it will be automatically changed to returned periods like `M1/M2/M3/M6` etc.

New structure: 
![image](https://github.com/user-attachments/assets/7886ee7f-301e-4bb5-9f94-01cf0074213c)
