### PR TITLE
Updated Highcharts and Dashboards to latest releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,8 @@
                 "webpack-cli": "^5.1.4"
             },
             "peerDependencies": {
-                "@highcharts/dashboards": ">=2.3.0",
-                "highcharts": ">=11.4.0"
+                "@highcharts/dashboards": "^3.3.0",
+                "highcharts": "^12.2.0"
             }
         },
         "node_modules/@aws-crypto/crc32": {
@@ -1201,9 +1201,9 @@
             }
         },
         "node_modules/@highcharts/dashboards": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@highcharts/dashboards/-/dashboards-2.3.0.tgz",
-            "integrity": "sha512-YWL0OLsXk+uGhJ5GaA3q+kq5/AJ/FxN9o6SgCBBIkcogTlnWVTgpy/TBh+xDqlea0+Er5p8pL7HPwNuFn5wyIw==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@highcharts/dashboards/-/dashboards-3.3.0.tgz",
+            "integrity": "sha512-WuVj9dFADpjfKLuMwDys31TmRAF8hfS7ln5qUOs57gwh0Rcc/8qn8k+ABvXVUBNbuAEUV5Z3MHG8HHJP9EMFQA==",
             "license": "https://www.highcharts.com/license",
             "peer": true,
             "peerDependencies": {
@@ -3943,9 +3943,9 @@
             }
         },
         "node_modules/highcharts": {
-            "version": "11.4.6",
-            "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-11.4.6.tgz",
-            "integrity": "sha512-ntFZ053giEEquAxza+HlOWiLQyCLOjQ3M3EV4r6LoSNKS/fz2S0EKGl8G7Jls9EaYmdAHecB/vL4hGI2J1Ud9g==",
+            "version": "12.2.0",
+            "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-12.2.0.tgz",
+            "integrity": "sha512-UUN+osTP3aeGc4KmoMuWAjzpKif8GYHFozzYI4O8h1ILGof25M/ZGBpXLvgqf1z0LVh7N9eG7i0HnzMfjcR4nA==",
             "license": "https://www.highcharts.com/license",
             "peer": true
         },

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
         ]
     },
     "peerDependencies": {
-        "@highcharts/dashboards": ">=2.3.0",
-        "highcharts": ">=11.4.0"
+        "@highcharts/dashboards": "^3.3.0",
+        "highcharts": "^12.2.0"
     },
     "scripts": {
         "api": "npm run webpack && npm run api:server",


### PR DESCRIPTION
Updated Highcharts and Dashboards versions to the latest releases. From now on, Morningstar connectors require using the Dashboards version 3.