### PR TITLE
Docs: Fixed broken URLs.

### DIFF
--- a/docs/connectors/morningstar/screeners/screener.md
+++ b/docs/connectors/morningstar/screeners/screener.md
@@ -4,8 +4,8 @@ Filter thousands of investments to quickly find those matching your criteria. Ov
 
 ## Capabilities
 
-- [Investment Screener](investment-screener.md)
-- [Investor Preferences](investor-preferences.md)
-- [ESG Screener](esg-screener.md)
-- [Regulatory Screener](regulatory-screener.md)
-- [Find Similar](find-similar-screener.md)
+- [Investment Screener](https://www.highcharts.com/docs/morningstar/screeners/investment-screener)
+- [Investor Preferences](https://www.highcharts.com/docs/morningstar/screeners/investor-preferences)
+- [ESG Screener](https://www.highcharts.com/docs/morningstar/screeners/esg-screener)
+- [Regulatory Screener](https://www.highcharts.com/docs/morningstar/screeners/regulatory-screener)
+- [Find Similar](https://www.highcharts.com/docs/morningstar/screeners/find-similar-screener)

--- a/docs/connectors/morningstar/time-series/time-series.md
+++ b/docs/connectors/morningstar/time-series/time-series.md
@@ -6,15 +6,15 @@ period.
 
 ## Capabilities
 
-- [Cumulative Return](cumulative-return.md)
-- [Dividend](dividend.md)
-- [Growth](growth.md)
-- [OHLCV](ohlcv.md)
-- [Price](price.md)
-- [Rating](rating.md)
-- [Regulatory News Announcements](../regulatory-news-announcements.md)
-- [Return](return.md)
-- [Rolling Return](rolling-return.md)
+- [Cumulative Return](https://www.highcharts.com/docs/morningstar/time-series/cumulative-return)
+- [Dividend](https://www.highcharts.com/docs/morningstar/time-series/dividend)
+- [Growth](https://www.highcharts.com/docs/morningstar/time-series/growth)
+- [OHLCV](https://www.highcharts.com/docs/morningstar/time-series/ohlcv)
+- [Price](https://www.highcharts.com/docs/morningstar/time-series/price)
+- [Rating](https://www.highcharts.com/docs/morningstar/time-series/rating)
+- [Regulatory News Announcements](https://www.highcharts.com/docs/morningstar/regulatory-news-announcements)
+- [Return](https://www.highcharts.com/docs/morningstar/time-series/return)
+- [Rolling Return](https://www.highcharts.com/docs/morningstar/time-series/rolling-return)
 
 
 For more details, see [Morningstar’s Time Series API].


### PR DESCRIPTION
General rule: use absolute, not relative paths.