### PR TITLE
Fixed empty columns in MetaConverter

### DIFF
--- a/src/Shared/Converters/MetaConverter.ts
+++ b/src/Shared/Converters/MetaConverter.ts
@@ -94,9 +94,6 @@ export class MetaConverter extends MorningstarConverter {
         const metaTypeStr = 'Meta' + (hasMultiple ? `_${id}` : '');
         const valueTypeStr = 'Value' + (hasMultiple ? `_${id}` : '');
 
-        table.setColumn(metaTypeStr);
-        table.setColumn(valueTypeStr);
-
         const rows = [
             ['Id', securityDetails.Id],
             ['InceptionDate', securityDetails.InceptionDate],
@@ -134,8 +131,18 @@ export class MetaConverter extends MorningstarConverter {
             ['FundAttributes_UCITS', securityDetails.FundAttributes?.UCITS]
         ];
 
+        const metaTypes: string[] = [],
+            metaValues: ( string | number | undefined | boolean )[]  = [];
+
+        // Split metaTypes and values into arrays
+        rows.forEach((row) => {
+            metaTypes.push(row[0] as string);
+            metaValues.push(row[1]);
+        });
+
         // Populate table
-        table.setRows(rows);
+        table.setColumn(metaTypeStr, metaTypes);
+        table.setColumn(valueTypeStr, metaValues);
 
         // Update metadata
         if (hasMultiple) {

--- a/tests/SecurityCompare/SecurityCompareConnector.test.ts
+++ b/tests/SecurityCompare/SecurityCompareConnector.test.ts
@@ -249,7 +249,8 @@ export async function portfolioHoldings (
 
     Assert.deepStrictEqual(
         connector.table.getColumnNames(),
-        ['PortfolioHoldings_Id_F0GBR050DD',
+        [
+            'PortfolioHoldings_Id_F0GBR050DD',
             'PortfolioHoldings_ExternalId_F0GBR050DD',
             'PortfolioHoldings_DetailHoldingTypeId_F0GBR050DD',
             'PortfolioHoldings_ExternalName_F0GBR050DD',

--- a/tests/SecurityCompare/SecurityCompareConnector.test.ts
+++ b/tests/SecurityCompare/SecurityCompareConnector.test.ts
@@ -246,10 +246,10 @@ export async function portfolioHoldings (
 
     await connector.load();
 
+
     Assert.deepStrictEqual(
         connector.table.getColumnNames(),
-        [
-            'PortfolioHoldings_Id_F0GBR050DD',
+        ['PortfolioHoldings_Id_F0GBR050DD',
             'PortfolioHoldings_ExternalId_F0GBR050DD',
             'PortfolioHoldings_DetailHoldingTypeId_F0GBR050DD',
             'PortfolioHoldings_ExternalName_F0GBR050DD',
@@ -281,8 +281,8 @@ export async function portfolioHoldings (
             'PortfolioHoldings_GlobalSectorId_F00000Q5PZ',
             'PortfolioHoldings_NumberOfShare_F00000Q5PZ',
             'PortfolioHoldings_GICSIndustryId_F00000Q5PZ',
-            'PortfolioHoldings_ShareChange_F00000Q5PZ',
-            'PortfolioHoldings_CUSIP_F00000Q5PZ'
+            'PortfolioHoldings_CUSIP_F00000Q5PZ',
+            'PortfolioHoldings_ShareChange_F00000Q5PZ'
         ],
         'PortfolioHoldings table should exist of expected columns'
     );


### PR DESCRIPTION
Fixed empty columns in MetaConverter using `SecurityCompare`.