### PR TITLE
Refactored XRay column names.

### DIFF
--- a/demos/dashboards-xray-benchmark/demo.js
+++ b/demos/dashboards-xray-benchmark/demo.js
@@ -124,28 +124,28 @@ async function displaySecurityDetails (postmanJSON) {
             dataGridOptions: {
                 header: [{
                     format: 'Type',
-                    columnId: 'MorningstarEUR3_L_Categories'
+                    columnId: 'MorningstarEUR3_Type'
                 }, {
                     format: 'Long',
-                    columnId: 'MorningstarEUR3_L_Values'
+                    columnId: 'MorningstarEUR3_L'
                 }, {
                     format: 'Long (Benchmark)',
-                    columnId: 'MorningstarEUR3_L_Values_Benchmark'
+                    columnId: 'MorningstarEUR3_L_Benchmark'
                 }, { 
                     format: 'Net',
-                    columnId: 'MorningstarEUR3_N_Values'
+                    columnId: 'MorningstarEUR3_N'
                 },  {
                     format: 'Net (Benchmark)',
-                    columnId: 'MorningstarEUR3_N_Values_Benchmark'
+                    columnId: 'MorningstarEUR3_N_Benchmark'
                 }, {
                     format: 'Short',
-                    columnId: 'MorningstarEUR3_S_Values'
+                    columnId: 'MorningstarEUR3_S'
                 }, {
                     format: 'Short (Benchmark)',
-                    columnId: 'MorningstarEUR3_S_Values_Benchmark'
+                    columnId: 'MorningstarEUR3_S_Benchmark'
                 }],
                 columns: [{
-                    id: 'MorningstarEUR3_L_Categories',
+                    id: 'MorningstarEUR3_Type',
                     cells: {
                         formatter: function () {
                             return this.value !== void 0 ?
@@ -153,32 +153,32 @@ async function displaySecurityDetails (postmanJSON) {
                         }
                     }
                 }, {
-                    id: 'MorningstarEUR3_L_Values',
+                    id: 'MorningstarEUR3_L',
                     cells: {
                         format: '{value:.2f}%'
                     }
                 }, {
-                    id: 'MorningstarEUR3_L_Values_Benchmark',
+                    id: 'MorningstarEUR3_L_Benchmark',
                     cells: {
                         format: '{value:.2f}%'
                     }
                 }, {
-                    id: 'MorningstarEUR3_N_Values',
+                    id: 'MorningstarEUR3_N',
                     cells: {
                         format: '{value:.2f}%'
                     }
                 }, {
-                    id: 'MorningstarEUR3_N_Values_Benchmark',
+                    id: 'MorningstarEUR3_N_Benchmark',
                     cells: {
                         format: '{value:.2f}%'
                     }
                 }, {
-                    id: 'MorningstarEUR3_S_Values',
+                    id: 'MorningstarEUR3_S',
                     cells: {
                         format: '{value:.2f}%'
                     }
                 }, {
-                    id: 'MorningstarEUR3_S_Values_Benchmark',
+                    id: 'MorningstarEUR3_S_Benchmark',
                     cells: {
                         format: '{value:.2f}%'
                     }
@@ -194,14 +194,14 @@ async function displaySecurityDetails (postmanJSON) {
             title: 'Global Stock Sector',
             dataGridOptions: {
                 header: [{
-                    format: 'Net',
-                    columnId: 'N_Categories'
+                    format: 'Category',
+                    columnId: 'Type'
                 }, {
-                    format: 'Values',
-                    columnId: 'N_Values'
+                    format: 'Value',
+                    columnId: 'N'
                 }],
                 columns: [{
-                    id: 'N_Categories',
+                    id: 'Type',
                     cells: {
                         formatter: function () {
                             return this.value !== void 0 ?
@@ -209,7 +209,7 @@ async function displaySecurityDetails (postmanJSON) {
                         }
                     }
                 }, {
-                    id: 'N_Values',
+                    id: 'N',
                     cells: {
                         format: '{value:.2f}%'
                     }
@@ -225,17 +225,17 @@ async function displaySecurityDetails (postmanJSON) {
             title: 'Regional Exposure',
             dataGridOptions: {
                 header: [{
-                    format: 'Net',
-                    columnId: 'N_Categories'
+                    format: 'Category',
+                    columnId: 'Type'
                 }, {
-                    format: 'Values',
-                    columnId: 'N_Values'
+                    format: 'Value',
+                    columnId: 'N'
                 }, {
-                    format: 'Values (Benchmark)',
-                    columnId: 'N_Values_Benchmark'
+                    format: 'Value (Benchmark)',
+                    columnId: 'N_Benchmark'
                 }],
                 columns: [{
-                    id: 'N_Categories',
+                    id: 'Type',
                     cells: {
                         formatter: function () {
                             return this.value !== void 0 ?
@@ -243,12 +243,12 @@ async function displaySecurityDetails (postmanJSON) {
                         }
                     }
                 }, {
-                    id: 'N_Values',
+                    id: 'N',
                     cells: {
                         format: '{value:.2f}%'
                     }
                 }, {
-                    id: 'N_Values_Benchmark',
+                    id: 'N_Benchmark',
                     cells: {
                         format: '{value:.2f}%'
                     }
@@ -264,14 +264,17 @@ async function displaySecurityDetails (postmanJSON) {
             title: 'Risk Statistics',
             dataGridOptions: {
                 header: [{
-                    format: 'Sharpe Ratio M36',
-                    columnId: 'SharpeRatio_M_M36'
+                    format: 'Sharpe Ratio Period',
+                    columnId: 'SharpeRatio_TimePeriod'
+                }, {
+                    format: 'Sharpe Ratio',
+                    columnId: 'SharpeRatio'
                 }, {
                     format: 'Standard Deviation Period',
                     columnId: 'StandardDeviation_TimePeriod'
                 }, {
                     format: 'Standard Deviation',
-                    columnId: 'StandardDeviation_Values'
+                    columnId: 'StandardDeviation'
                 }]
             }
         }, {
@@ -285,16 +288,16 @@ async function displaySecurityDetails (postmanJSON) {
             dataGridOptions: {
                 header: [{
                     format: 'Category',
-                    columnId: 'N_Categories'
+                    columnId: 'Type'
                 }, {
                     format: 'Value',
-                    columnId: 'N_Values'
+                    columnId: 'N'
                 }, {
                     format: 'Value (Benchmark)',
-                    columnId: 'N_Values_Benchmark'
+                    columnId: 'N_Benchmark'
                 }],
                 columns: [{
-                    id: 'N_Categories',
+                    id: 'Type',
                     cells: {
                         formatter: function () {
                             return this.value !== void 0 ?
@@ -302,12 +305,12 @@ async function displaySecurityDetails (postmanJSON) {
                         }
                     }
                 }, {
-                    id: 'N_Values',
+                    id: 'N',
                     cells: {
                         format: '{value:.2f}%'
                     }
                 }, {
-                    id: 'N_Values_Benchmark',
+                    id: 'N_Benchmark',
                     cells: {
                         format: '{value:.2f}%'
                     }
@@ -324,13 +327,13 @@ async function displaySecurityDetails (postmanJSON) {
             dataGridOptions: {
                 header: [{
                     format: 'Time Period',
-                    columnId: 'MonthEnd_TimePeriod'
+                    columnId: 'TotalReturn_MonthEnd_TimePeriod'
                 }, {
                     format: 'Value (£)',
-                    columnId: 'MonthEnd_Value'
+                    columnId: 'TotalReturn_MonthEnd_Value'
                 }, {
-                    format: 'Value (Benchmark, £)',
-                    columnId: 'MonthEnd_Value_Benchmark'
+                    format: 'Value (£, Benchmark)',
+                    columnId: 'TotalReturn_MonthEnd_Value_Benchmark'
                 }]
             }
         }, {
@@ -344,22 +347,22 @@ async function displaySecurityDetails (postmanJSON) {
             dataGridOptions: {
                 header: [{
                     format: 'M1 (Date)',
-                    columnId: 'TotalReturn_M1_Benchmark'
+                    columnId: 'TotalReturn_M1_Monthly_Date_Benchmark'
                 }, {
                     format: 'Value (£)',
-                    columnId: 'TotalReturn_M1_Value_Benchmark'
+                    columnId: 'TotalReturn_M1_Monthly_Value_Benchmark'
                 }, {
                     format: 'M3 (Date)',
-                    columnId: 'TotalReturn_M3_Benchmark'
+                    columnId: 'TotalReturn_M3_Quarterly_Date_Benchmark'
                 }, {
                     format: 'Value (£)',
-                    columnId: 'TotalReturn_M3_Value_Benchmark'
+                    columnId: 'TotalReturn_M3_Quarterly_Value_Benchmark'
                 }, {
                     format: 'M12 (Date)',
-                    columnId: 'TotalReturn_M12_Benchmark'
+                    columnId: 'TotalReturn_M12_Annual_Date_Benchmark'
                 }, {
                     format: 'Value (£)',
-                    columnId: 'TotalReturn_M12_Value_Benchmark'
+                    columnId: 'TotalReturn_M12_Annual_Value_Benchmark'
                 }]
             }
         }, {

--- a/demos/dashboards-xray/demo.js
+++ b/demos/dashboards-xray/demo.js
@@ -91,13 +91,13 @@ async function displaySecurityDetails (postmanJSON) {
             dataGridOptions: {
                 header: [{
                     format: 'Net',
-                    columnId: 'N_Categories'
+                    columnId: 'Type'
                 }, {
                     format: 'Values',
-                    columnId: 'N_Values'
+                    columnId: 'N'
                 }],
                 columns: [{
-                    id: 'N_Categories',
+                    id: 'Type',
                     cells: {
                         formatter: function () {
                             return this.value !== void 0 ?
@@ -117,25 +117,25 @@ async function displaySecurityDetails (postmanJSON) {
             dataGridOptions: {
                 header: [{
                     format: 'Long',
-                    columnId: 'MorningstarEUR3_L_Categories'
+                    columnId: 'MorningstarEUR3_Type'
                 }, {
                     format: 'Values',
-                    columnId: 'MorningstarEUR3_L_Values'
+                    columnId: 'MorningstarEUR3_L'
                 }, {
                     format: 'Net',
-                    columnId: 'MorningstarEUR3_N_Categories'
+                    columnId: 'MorningstarEUR3_Type'
                 }, {
                     format: 'Values',
-                    columnId: 'MorningstarEUR3_N_Values'
+                    columnId: 'MorningstarEUR3_N'
                 }, {
                     format: 'Short',
-                    columnId: 'MorningstarEUR3_S_Categories'
+                    columnId: 'MorningstarEUR3_Type'
                 }, {
                     format: 'Values',
-                    columnId: 'MorningstarEUR3_S_Values'
+                    columnId: 'MorningstarEUR3_S'
                 }],
                 columns: [{
-                    id: 'MorningstarEUR3_L_Categories',
+                    id: 'MorningstarEUR3_Type',
                     cells: {
                         formatter: function () {
                             return this.value !== void 0 ?
@@ -143,7 +143,7 @@ async function displaySecurityDetails (postmanJSON) {
                         }
                     }
                 }, {
-                    id: 'MorningstarEUR3_N_Categories',
+                    id: 'MorningstarEUR3_Type',
                     cells: {
                         formatter: function () {
                             return this.value !== void 0 ?
@@ -151,7 +151,7 @@ async function displaySecurityDetails (postmanJSON) {
                         }
                     }
                 }, {
-                    id: 'MorningstarEUR3_S_Categories',
+                    id: 'MorningstarEUR3_Type',
                     cells: {
                         formatter: function () {
                             return this.value !== void 0 ?
@@ -171,13 +171,13 @@ async function displaySecurityDetails (postmanJSON) {
             dataGridOptions: {
                 header: [{
                     format: 'Net',
-                    columnId: 'N_Categories'
+                    columnId: 'Type'
                 }, {
                     format: 'Values',
-                    columnId: 'N_Values'
+                    columnId: 'N'
                 }],
                 columns: [{
-                    id: 'N_Categories',
+                    id: 'Type',
                     cells: {
                         formatter: function () {
                             return this.value !== void 0 ?

--- a/src/Shared/Converters/HistoricalPerformanceConverter.ts
+++ b/src/Shared/Converters/HistoricalPerformanceConverter.ts
@@ -62,8 +62,10 @@ export class HistoricalPerformanceConverter extends MorningstarConverter {
             json = isBenchmark ? benchmark[0] : options.json;
 
         for (const historicalPerformance of json.historicalPerformanceSeries || []) {
-            const periodRowId = `${historicalPerformance.returnType}_${historicalPerformance.timePeriod}` + benchmarkSuffix;
-            const valueRowId = `${historicalPerformance.returnType}_${historicalPerformance.timePeriod}_Value` + benchmarkSuffix;
+            const { returnType, timePeriod, frequency } = historicalPerformance,
+                columnString = `${returnType}_${timePeriod}_${frequency}`,
+                periodRowId = `${columnString}_Date` + benchmarkSuffix,
+                valueRowId = `${columnString}_Value` + benchmarkSuffix;
 
             let rowIndex = 0;
 

--- a/src/Shared/Converters/RiskStatisticsConverter.ts
+++ b/src/Shared/Converters/RiskStatisticsConverter.ts
@@ -62,17 +62,35 @@ export class RiskStatisticsConverter extends MorningstarConverter {
             json = isBenchmark ? benchmark[0].riskStatistics : options.json.riskStatistics;
 
         if (json?.sharpeRatio) {
+            let i = 0;
             for (const sharpeRatio of json.sharpeRatio) {
-                const columnName = `SharpeRatio_${sharpeRatio.frequency}_${sharpeRatio.timePeriod}` + benchmarkSuffix;
-                table.setCell(columnName, 0, sharpeRatio.value);
+                table.setCell(
+                    'SharpeRatio_TimePeriod' + benchmarkSuffix,
+                    i,
+                    sharpeRatio.timePeriod
+                );
+                table.setCell(
+                    'SharpeRatio' + benchmarkSuffix,
+                    i,
+                    sharpeRatio.value
+                );
+                i++;
             }
         }
 
         if (json?.standardDeviation) {
             let i = 0;
             for (const standardDeviation of json.standardDeviation) {
-                table.setCell('StandardDeviation_TimePeriod', i, standardDeviation.timePeriod);
-                table.setCell('StandardDeviation_Values', i, standardDeviation.value);
+                table.setCell(
+                    'StandardDeviation_TimePeriod' + benchmarkSuffix,
+                    i,
+                    standardDeviation.timePeriod
+                );
+                table.setCell(
+                    'StandardDeviation' + benchmarkSuffix,
+                    i,
+                    standardDeviation.value
+                );
                 i++;
             }
         }

--- a/src/Shared/Converters/XRayAssetAllocationsConverter.ts
+++ b/src/Shared/Converters/XRayAssetAllocationsConverter.ts
@@ -63,9 +63,8 @@ export class XRayAssetAllocationsConverter extends MorningstarConverter {
 
         if (json?.assetAllocation) {
             for (const asset of json.assetAllocation) {
-                const columnName = `${asset.type}_${asset.salePosition}`,
-                    categoryStr = `${columnName}_Categories` + benchmarkSuffix,
-                    valueStr = `${columnName}_Values` + benchmarkSuffix,
+                const categoryStr = `${asset.type}_Type` + benchmarkSuffix,
+                    valueStr = `${asset.type}_${asset.salePosition}` + benchmarkSuffix,
                     values = asset.values,
                     valueIndex = Object.keys(values);
 

--- a/src/Shared/Converters/XRayCreditQualityConverter.ts
+++ b/src/Shared/Converters/XRayCreditQualityConverter.ts
@@ -66,8 +66,8 @@ export class XRayCreditQualityConverter extends MorningstarConverter {
 
         if (json?.creditQuality) {
             for (const creditQuality of json.creditQuality) {
-                const categoryStr = `${creditQuality.salePosition}_Categories` + benchmarkSuffix,
-                    valueStr = `${creditQuality.salePosition}_Values` + benchmarkSuffix,
+                const categoryStr = 'Type' + benchmarkSuffix,
+                    valueStr = creditQuality.salePosition + benchmarkSuffix,
                     values = creditQuality.values,
                     valueIndex = Object.keys(values);
 

--- a/src/Shared/Converters/XRayGlobalStockSectorConverter.ts
+++ b/src/Shared/Converters/XRayGlobalStockSectorConverter.ts
@@ -63,8 +63,8 @@ export class XRayGlobalStockSectorConverter extends MorningstarConverter {
 
         if (json?.globalStockSector) {
             for (const sector of json.globalStockSector) {
-                const categoryStr = `${sector.salePosition}_Categories` + benchmarkSuffix,
-                    valueStr = `${sector.salePosition}_Values` + benchmarkSuffix,
+                const categoryStr = 'Type' + benchmarkSuffix,
+                    valueStr = `${sector.salePosition}` + benchmarkSuffix,
                     values = sector.values,
                     valueIndex = Object.keys(values);
 

--- a/src/Shared/Converters/XRayRegionalExposureConverter.ts
+++ b/src/Shared/Converters/XRayRegionalExposureConverter.ts
@@ -63,8 +63,8 @@ export class XRayRegionalExposureConverter extends MorningstarConverter {
 
         if (json?.regionalExposure) {
             for (const exposure of json.regionalExposure) {
-                const categoryStr = `${exposure.salePosition}_Categories` + benchmarkSuffix,
-                    valueStr = `${exposure.salePosition}_Values` + benchmarkSuffix,
+                const categoryStr = 'Type' + benchmarkSuffix,
+                    valueStr = `${exposure.salePosition}` + benchmarkSuffix,
                     values = exposure.values,
                     valueIndex = Object.keys(values);
 

--- a/src/Shared/Converters/XRayStyleBoxConverter.ts
+++ b/src/Shared/Converters/XRayStyleBoxConverter.ts
@@ -20,6 +20,7 @@
 
 import MorningstarConverter from '../MorningstarConverter';
 import type { XRayConverterOptions } from '../../XRay';
+import { STYLE_BOX_VALUES } from '../Utilities';
 
 /* *
  *
@@ -72,6 +73,10 @@ export class XRayStyleBoxConverter extends MorningstarConverter {
                     table.setCell(categoryStr, i, valueIndex[i]);
                     table.setCell(valueStr, i, values[parseInt(valueIndex[i])]);
                 }
+
+                // Set destructured x & y values
+                table.setColumn('Style' + benchmarkSuffix, STYLE_BOX_VALUES.X);
+                table.setColumn('Size' + benchmarkSuffix, STYLE_BOX_VALUES.Y);
             }
         }
     }

--- a/src/Shared/Converters/XRayStyleBoxConverter.ts
+++ b/src/Shared/Converters/XRayStyleBoxConverter.ts
@@ -63,8 +63,8 @@ export class XRayStyleBoxConverter extends MorningstarConverter {
 
         if (json?.styleBox) {
             for (const styleBox of json.styleBox) {
-                const categoryStr = `${styleBox.salePosition}_Categories` + benchmarkSuffix,
-                    valueStr = `${styleBox.salePosition}_Values` + benchmarkSuffix,
+                const categoryStr = 'Type' + benchmarkSuffix,
+                    valueStr = `${styleBox.salePosition}` + benchmarkSuffix,
                     values = styleBox.values,
                     valueIndex = Object.keys(values);
 

--- a/src/Shared/Converters/XRayTrailingPerformanceConverter.ts
+++ b/src/Shared/Converters/XRayTrailingPerformanceConverter.ts
@@ -62,8 +62,10 @@ export class XRayTrailingPerformanceConverter extends MorningstarConverter {
             json = isBenchmark ? benchmark[0] : options.json;
 
         for (const trailingPerformance of json.trailingPerformance || []) {
-            const periodRowId = `${trailingPerformance.type}_TimePeriod` + benchmarkSuffix;
-            const valueRowId = `${trailingPerformance.type}_Value` + benchmarkSuffix;
+            const { returnType, type } = trailingPerformance,
+                columnString = `${returnType}_${type}`,
+                periodRowId = `${columnString}_TimePeriod` + benchmarkSuffix,
+                valueRowId = `${columnString}_Value` + benchmarkSuffix;
 
             let rowIndex = 0;
 

--- a/src/Shared/Utilities.ts
+++ b/src/Shared/Utilities.ts
@@ -1,2 +1,6 @@
 export const UTF_PIPE = '|';
 export const UTF_COLON = ':';
+export const STYLE_BOX_VALUES = {
+    X: [0, 1, 2, 0, 1, 2, 0, 1, 2],
+    Y: [2, 2, 2, 1, 1, 1, 0, 0, 0]
+};

--- a/tests/XRay/Breakdown.test.ts
+++ b/tests/XRay/Breakdown.test.ts
@@ -77,7 +77,8 @@ export async function portfolioDataPoints (
                 'AssetAllocationMorningstarEUR3',
                 'GlobalStockSector',
                 'RegionalExposure',
-                'StyleBox'
+                'StyleBox',
+                ['PerformanceReturn', 'M0', 'M1', 'M2', 'M3', 'M6', 'M12']
             ]
         },
         holdings: [
@@ -100,6 +101,10 @@ export async function portfolioDataPoints (
         'MorningstarEUR3_N',
         'MorningstarEUR3_L',
         'MorningstarEUR3_S'
+    ],
+    trailingPerformanceColumnNames = [
+        'TotalReturn_MonthEnd_TimePeriod',
+        'TotalReturn_MonthEnd_Value'
     ];
     await connector.load();
 
@@ -193,6 +198,35 @@ export async function portfolioDataPoints (
     Assert.strictEqual(
         columnNames.length,
         connector.dataTables.StyleBox.modified.getRowCount(),
+        'Original and inverted table should have an inverted amount of columns and rows.'
+    );
+
+        Assert.strictEqual(
+        columnNames.length,
+        connector.dataTables.RegionalExposure.modified.getRowCount(),
+        'Original and inverted table should have an inverted amount of columns and rows.'
+    );
+
+    Assert.deepStrictEqual(
+        connector.dataTables.TrailingPerformance.getColumnNames(),
+        trailingPerformanceColumnNames,
+        'Connector columns should return expected names.'
+    );
+
+    Assert.ok(
+        connector.dataTables.TrailingPerformance.getRowCount() > 0,
+        'Connector should not return empty rows.'
+    );
+
+    Assert.deepStrictEqual(
+        connector.dataTables.TrailingPerformance.modified.getColumn('columnNames'),
+        trailingPerformanceColumnNames,
+        'Row names of inverted table should be the same as original column names.'
+    );
+
+    Assert.strictEqual(
+        trailingPerformanceColumnNames.length,
+        connector.dataTables.TrailingPerformance.modified.getRowCount(),
         'Original and inverted table should have an inverted amount of columns and rows.'
     );
 }

--- a/tests/XRay/Breakdown.test.ts
+++ b/tests/XRay/Breakdown.test.ts
@@ -56,35 +56,47 @@ export async function benchmarkBreakdownLoad (
     Assert.deepStrictEqual(
         connector.dataTables.GlobalStockSector.getColumnNames(),
         [
-            'N_Categories',
-            'N_Values'
+            'Type',
+            'N'
         ],
         'GlobalStockSector table should contain only Portfolio columns.'
     );
 
+    Assert.deepStrictEqual(
+        connector.dataTables.RegionalExposure.getColumnNames(),
+        [
+            'Type',
+            'N',
+            'Type_Benchmark',
+            'N_Benchmark'
+        ],
+        `RegionalExposure table should contain both,
+        Portfolio and Benchmark, columns.`
+    );
 
-    // Both, Portfolio and Benchmark
-    ['RegionalExposure', 'StyleBox'].forEach(tableName => {
-        Assert.deepStrictEqual(
-            connector.dataTables[tableName].getColumnNames(),
-            [
-                'N_Categories',
-                'N_Values',
-                'N_Categories_Benchmark',
-                'N_Values_Benchmark'
-            ],
-            `${tableName} table should contain both,
-            Portfolio and Benchmark, columns.`
-        );
-    });
+    Assert.deepStrictEqual(
+        connector.dataTables.StyleBox.getColumnNames(),
+        [
+            'Type',
+            'N',
+            'Style',
+            'Size',
+            'Type_Benchmark',
+            'N_Benchmark',
+            'Style_Benchmark',
+            'Size_Benchmark'
+        ],
+        `StyleBox table should contain both,
+        Portfolio and Benchmark, columns.`
+    );
 
     Assert.deepStrictEqual(
         connector.dataTables.TrailingPerformance.getColumnNames(),
         [
-            'MonthEnd_TimePeriod',
-            'MonthEnd_Value',
-            'MonthEnd_TimePeriod_Benchmark',
-            'MonthEnd_Value_Benchmark'
+            'TotalReturn_MonthEnd_TimePeriod',
+            'TotalReturn_MonthEnd_Value',
+            'TotalReturn_MonthEnd_TimePeriod_Benchmark',
+            'TotalReturn_MonthEnd_Value_Benchmark'
         ],
         `TrailingPerformance table should contain both,
         Portfolio and Benchmark, columns.`
@@ -93,24 +105,18 @@ export async function benchmarkBreakdownLoad (
     Assert.deepStrictEqual(
         connector.dataTables.AssetAllocation.getColumnNames(),
         [
-            'MorningstarEUR3_N_Categories',
-            'MorningstarEUR3_N_Values',
-            'MorningstarEUR3_L_Categories',
-            'MorningstarEUR3_L_Values',
-            'MorningstarEUR3_S_Categories',
-            'MorningstarEUR3_S_Values',
-            'MorningstarEUR3_N_Categories_Benchmark',
-            'MorningstarEUR3_N_Values_Benchmark',
-            'MorningstarEUR3_L_Categories_Benchmark',
-            'MorningstarEUR3_L_Values_Benchmark',
-            'MorningstarEUR3_S_Categories_Benchmark',
-            'MorningstarEUR3_S_Values_Benchmark',
-            'Default1_N_Categories_Benchmark',
-            'Default1_N_Values_Benchmark',
-            'Default1_L_Categories_Benchmark',
-            'Default1_L_Values_Benchmark',
-            'Default1_S_Categories_Benchmark',
-            'Default1_S_Values_Benchmark'
+            'MorningstarEUR3_Type',
+            'MorningstarEUR3_N',
+            'MorningstarEUR3_L',
+            'MorningstarEUR3_S',
+            'MorningstarEUR3_Type_Benchmark',
+            'MorningstarEUR3_N_Benchmark',
+            'MorningstarEUR3_L_Benchmark',
+            'MorningstarEUR3_S_Benchmark',
+            'Default1_Type_Benchmark',
+            'Default1_N_Benchmark',
+            'Default1_L_Benchmark',
+            'Default1_S_Benchmark'
         ],
         `TrailingPerformance table should contain both,
         Portfolio and Benchmark, columns.`
@@ -120,10 +126,10 @@ export async function benchmarkBreakdownLoad (
     Assert.deepStrictEqual(
         connector.dataTables.TrailingPerformance.getColumnNames(),
         [
-            'MonthEnd_TimePeriod',
-            'MonthEnd_Value',
-            'MonthEnd_TimePeriod_Benchmark',
-            'MonthEnd_Value_Benchmark'
+            'TotalReturn_MonthEnd_TimePeriod',
+            'TotalReturn_MonthEnd_Value',
+            'TotalReturn_MonthEnd_TimePeriod_Benchmark',
+            'TotalReturn_MonthEnd_Value_Benchmark'
         ],
         'TrailingPerformance table should contain only Benchmark columns.'
     );
@@ -392,8 +398,8 @@ export async function creditQualityLoad (
         ]
     }),
     columnNames = [
-        'N_Categories',
-        'N_Values'
+        'Type',
+        'N'
     ];
     await connector.load();
 

--- a/tests/XRay/Breakdown.test.ts
+++ b/tests/XRay/Breakdown.test.ts
@@ -35,12 +35,12 @@ export async function breakdownLoad (
     Assert.deepStrictEqual(
         connector.dataTables.HistoricalPerformanceSeries.getColumnNames(),
         [
-            'TotalReturn_M1_Benchmark',
-            'TotalReturn_M1_Value_Benchmark',
-            'TotalReturn_M3_Benchmark',
-            'TotalReturn_M3_Value_Benchmark',
-            'TotalReturn_M12_Benchmark',
-            'TotalReturn_M12_Value_Benchmark'
+             'TotalReturn_M1_Monthly_Date_Benchmark',
+             'TotalReturn_M1_Monthly_Value_Benchmark',
+             'TotalReturn_M3_Quarterly_Date_Benchmark',
+             'TotalReturn_M3_Quarterly_Value_Benchmark',
+             'TotalReturn_M12_Annual_Date_Benchmark',
+             'TotalReturn_M12_Annual_Value_Benchmark'
         ],
         'Connector table should exist of expected columns.'
     );
@@ -92,16 +92,14 @@ export async function portfolioDataPoints (
         ]
     }),
     columnNames = [
-        'N_Categories',
-        'N_Values'
+        'Type',
+        'N'
     ],
     assetAllocationColumnNames = [
-        'MorningstarEUR3_N_Categories',
-        'MorningstarEUR3_N_Values',
-        'MorningstarEUR3_L_Categories',
-        'MorningstarEUR3_L_Values',
-        'MorningstarEUR3_S_Categories',
-        'MorningstarEUR3_S_Values'
+        'MorningstarEUR3_Type',
+        'MorningstarEUR3_N',
+        'MorningstarEUR3_L',
+        'MorningstarEUR3_S'
     ];
     await connector.load();
 
@@ -123,7 +121,7 @@ export async function portfolioDataPoints (
     );
 
     Assert.strictEqual(
-        columnNames.length,
+        assetAllocationColumnNames.length,
         connector.dataTables.AssetAllocation.modified.getRowCount(),
         'Original and inverted table should have an inverted amount of columns and rows.'
     );

--- a/tests/XRay/Breakdown.test.ts
+++ b/tests/XRay/Breakdown.test.ts
@@ -105,6 +105,12 @@ export async function portfolioDataPoints (
     trailingPerformanceColumnNames = [
         'TotalReturn_MonthEnd_TimePeriod',
         'TotalReturn_MonthEnd_Value'
+    ],
+    styleBoxColumnNames = [
+        'Type',
+        'N',
+        'Style',
+        'Size'
     ];
     await connector.load();
 
@@ -180,7 +186,7 @@ export async function portfolioDataPoints (
 
     Assert.deepStrictEqual(
         connector.dataTables.StyleBox.getColumnNames(),
-        columnNames,
+        styleBoxColumnNames,
         'Connector columns should return expected names.'
     );
 
@@ -191,12 +197,12 @@ export async function portfolioDataPoints (
 
     Assert.deepStrictEqual(
         connector.dataTables.StyleBox.modified.getColumn('columnNames'),
-        columnNames,
+        styleBoxColumnNames,
         'Row names of inverted table should be the same as original column names.'
     );
 
     Assert.strictEqual(
-        columnNames.length,
+        styleBoxColumnNames.length,
         connector.dataTables.StyleBox.modified.getRowCount(),
         'Original and inverted table should have an inverted amount of columns and rows.'
     );

--- a/tests/XRay/RiskStatistics.test.ts
+++ b/tests/XRay/RiskStatistics.test.ts
@@ -31,9 +31,10 @@ export async function portfolioBreakdown (
     Assert.deepStrictEqual(
         connector.dataTables.RiskStatistics.getColumnNames(),
         [
-            'SharpeRatio_M_M36',
+            'SharpeRatio_TimePeriod',
+            'SharpeRatio',
             'StandardDeviation_TimePeriod',
-            'StandardDeviation_Values'
+            'StandardDeviation'
         ],
         'Connector columns should return expected names.'
     );


### PR DESCRIPTION
Adjusted `XRay`  column names to match v2.0 naming convention.
Previously, all of the returned data points were stored in one table. This has now been updated to support multiple data tables per connector, reducing number of requests and improving flexibility. Key changes include:
* Added splitting returned data points from connectors to multiple data tables.
* Added missing properties like `Type/ReturnType/Date/...`  to column names.
* Added `_Benchmark` suffix for all columns generated from benchmark data point type.
* Each returned data point is now accessible via a key in the `dataTables`, so in order to access data use `connector.dataTables['StyleBox']` or `connector.dataTables.StyleBox`, instead of the `connector.table` which won't work from v2.0+.
* Removed connector and converter name from column name.
* Renamed column names for converters:

| Converter Type                   | Column name -  before                                           | Column name - after           |
|-----------------------------|--------------------------------------------------|-----------------|
| AssetAllocations            | `XRay_MorningstarEUR3_N_Categories`                         | `MorningstarEUR3_Type` |
|                             | `XRay_MorningstarEUR3_L_Categories`            | `MorningstarEUR3_Type`    |
|                             | `XRay_MorningstarEUR3_S_Categories`            | `MorningstarEUR3_Type`    |
|                             | `XRay_MorningstarEUR3_N_Values`            | `MorningstarEUR3_N`    |
|                             | `XRay_MorningstarEUR3_L_Values`            | `MorningstarEUR3_L`    |
|                             | `XRay_MorningstarEUR3_S_Values`            | `MorningstarEUR3_S`    |
| CreditQuality              | *(new converter)*                       | `Type`          |
|                             | *(new converter)*                      | `N`     |
| GlobalStockSector| `XRay_GlobalStockSector_N_Categories`     | `Type`        |
|                    | `XRay_GlobalStockSector_N_Values`                                     | `N`              |
| HistoricalPerformanceSeries            | `XRay_TotalReturn_M1`                         | `TotalReturn_M1_Monthly_Date`          |
|                             | `XRay_TotalReturn_M1_Value`                       | `TotalReturn_M1_Monthly_Value`     |
|                             | `XRay_TotalReturn_M3`               | `TotalReturn_M3_Quarterly_Date` |
|                             | `XRay_TotalReturn_M3_Value`                            | `TotalReturn_M3_Quarterly_Value`             |
|                             | `XRay_TotalReturn_M12`                            | `TotalReturn_M12_Annual_Date`             |
|                             | `XRay_TotalReturn_M12_Value`                            | `TotalReturn_M12_Annual_Value`             |
| RegionalExposure             | `XRay_RegionalExposure_N_Categories`                        |  `Type`      |
|                             | `XRay_RegionalExposure_N_Values`                         | `N`          |
| RiskStatistics              | `XRay_SharpeRatio_M_M36`                        |  *(removed)*     |
|                             | `XRay_StandardDeviation_M_M36`                         | *(removed)*          |
|                             |                          | `SharpeRatio_TimePeriod`          |
|                             |                          | `SharpeRatio`          |
|                             |                          | `StandardDeviation_TimePeriod`          |
|                             |                          | `StandardDeviation`          |
| StyleBox             		  | `XRay_StyleBox_N_Categories`                       | `Type`          |
|                             | `XRay_StyleBox_N_Values`                     | `N`     |
|                             |               | `Style` |
|                             |                           | `Size`             |
| TrailingPerformance       | `XRay_MonthEnd_TimePeriod`                  | `TotalReturn_MonthEnd_TimePeriod`          |
|                             | `XRay_MonthEnd_Value`                     | `TotalReturn_MonthEnd_Value`             |
| UnderlyHoldings      | *(not changed)*                  |           |
