### PR TITLE
Updated docs and demos to match v2.0

### DIFF
--- a/demos/dashboards-compare-asset-allocations/demo.js
+++ b/demos/dashboards-compare-asset-allocations/demo.js
@@ -72,7 +72,7 @@ async function displaySecurityDetails (postmanJSON) {
                     columnAssignment: [{
                         seriesId: ids[0],
                         data: [
-                            'Type_' + ids[0],
+                            'MorningstarEUR3_Type_' + ids[0],
                             'MorningstarEUR3_N_' + ids[0]
                         ]
                     }]
@@ -110,7 +110,7 @@ async function displaySecurityDetails (postmanJSON) {
                     columnAssignment: [{
                         seriesId: ids[1],
                         data: [
-                            'Type_' + ids[1],
+                            'MorningstarEUR3_Type_' + ids[1],
                             'MorningstarEUR3_N_' + ids[1]
                         ]
                     }]

--- a/demos/stock-security-compare/demo.js
+++ b/demos/stock-security-compare/demo.js
@@ -32,10 +32,14 @@ async function displaySecurityDetails (postmanJSON) {
         series: ids.map(id => ({
             type: 'column',
             name: idNames[id],
-            data: connector.dataTables.TrailingPerformance.getRowObjects().map(obj => [
-                obj['TrailingPerformance_TimePeriod_' + id],
-                obj['TrailingPerformance_Value_' + id]
-            ])
+            data: connector.dataTables.TrailingPerformance.getRows(
+                void 0,
+                void 0,
+                [
+                    'Nav_DayEnd_TimePeriod_' + id,
+                    'Nav_DayEnd_Value_' + id
+                ]
+            )
         })),
         xAxis: {
             type: 'category'

--- a/demos/stock-securitydetails-asset-allocations/demo.js
+++ b/demos/stock-securitydetails-asset-allocations/demo.js
@@ -28,8 +28,8 @@ async function displayAssetAllocations (postmanJSON) {
         '99': 'Unclassified'
     };
 
-    const chartData = connector.dataTables['AssetAllocations'].getRowObjects().map(item => ({
-        name: typeMapping[item.Type],
+    const chartData = connector.dataTables.AssetAllocations.getRowObjects().map(item => ({
+        name: typeMapping[item.MorningstarEUR3_Type],
         y: item.MorningstarEUR3_N
     }));
 

--- a/demos/stock-securitydetails/demo.js
+++ b/demos/stock-securitydetails/demo.js
@@ -27,10 +27,11 @@ async function displaySecurityDetails (postmanJSON) {
         series: [{
             type: 'column',
             name: 'F0GBR050DD',
-            data: connector.dataTables.TrailingPerformance.getRowObjects().map(obj => [
-                obj.Nav_DayEnd_TimePeriod,
-                obj.Nav_DayEnd_Value
-            ])
+            data: connector.dataTables.TrailingPerformance.getRows(
+                void 0,
+                void 0,
+                ['Nav_DayEnd_TimePeriod', 'Nav_DayEnd_Value']
+            )
         }],
         xAxis: {
             type: 'category'

--- a/docs/connectors/morningstar/goal-analysis.md
+++ b/docs/connectors/morningstar/goal-analysis.md
@@ -18,8 +18,10 @@ In order to fetch the analysis, you can request for example:
 
 ```js
 const goalAnalysisConnector = new HighchartsConnectors.Morningstar.GoalAnalysisConnector({
-    postman: {
-        environmentJSON: postmanJSON
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
     },
     annualInvestment: 4800,
     assetClassWeights: [

--- a/docs/connectors/morningstar/regulatory-news-announcements.md
+++ b/docs/connectors/morningstar/regulatory-news-announcements.md
@@ -18,8 +18,10 @@ or `maxStories`.
 
 ```js
 const rnaNewsConnector = new HighchartsConnectors.Morningstar.RNANewsConnector({
-    postman: {
-        environmentJSON: postmanJSON
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
     },
     security: {
         id: 'GB00BLGZ9862',
@@ -55,8 +57,10 @@ Dashboards.board('container', {
             id: 'rna',
             type: 'MorningstarRNANews',
             options: {
-                postman: {
-                    environmentJSON: postmanJSON
+                api: {
+                    access: {
+                        token: 'your_access_token'
+                    }
                 },
                 security: {
                     id: 'GB00BLGZ9862',

--- a/docs/connectors/morningstar/risk-score.md
+++ b/docs/connectors/morningstar/risk-score.md
@@ -37,8 +37,10 @@ For more details, see [Morningstar’s RiskScore API].
 
 ```js
 const riskScoreConnector = new HighchartsConnectors.Morningstar.RiskScoreConnector({
-    postman: {
-        environmentJSON: postmanJSON
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
     },
     portfolios: [
         {

--- a/docs/connectors/morningstar/screeners/esg-screener.md
+++ b/docs/connectors/morningstar/screeners/esg-screener.md
@@ -27,6 +27,11 @@ Here is an example of how to use the ESG Screener connector:
 
 ```js
 const screenerConnector = new HighchartsConnectors.Morningstar.InvestmentScreenerConnector({
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
+    },
     page: 1,
     pageSize: 20,
     languageId: 'en-GB',
@@ -50,10 +55,7 @@ const screenerConnector = new HighchartsConnectors.Morningstar.InvestmentScreene
         'controversialWeapons',
         'renewableEnergyProductionInvolvement'
     ],
-    universeIds: ['FOALL$$ALL'],
-    postman: {
-        environmentJSON: postmanJSON
-    }
+    universeIds: ['FOALL$$ALL']
 });
 ```
 

--- a/docs/connectors/morningstar/screeners/find-similar-screener.md
+++ b/docs/connectors/morningstar/screeners/find-similar-screener.md
@@ -17,6 +17,11 @@ Here is an example of how to use the Find Similar Screener connector:
 
 ```js
 const screenerConnector = new HighchartsConnectors.Morningstar.InvestmentScreenerConnector({
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
+    },
     page: 1,
     pageSize: 20,
     languageId: 'en-GB',
@@ -40,10 +45,7 @@ const screenerConnector = new HighchartsConnectors.Morningstar.InvestmentScreene
         'ongoingCharge'
     ],
     sortOrder: 'Name+Asc',
-    universeIds: ['FOESP$$ALL'],
-    postman: {
-        environmentJSON: postmanJSON
-    }
+    universeIds: ['FOESP$$ALL']
 });
 ```
 

--- a/docs/connectors/morningstar/screeners/investment-screener.md
+++ b/docs/connectors/morningstar/screeners/investment-screener.md
@@ -27,6 +27,11 @@ Here is an example of how to use the Investment Screener connector:
 
 ```js
 const screenerConnector = new HighchartsConnectors.Morningstar.InvestmentScreenerConnector({
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
+    },
     page: 1,
     pageSize: 20,
     languageId: 'en-GB',
@@ -52,10 +57,7 @@ const screenerConnector = new HighchartsConnectors.Morningstar.InvestmentScreene
         'holdingTypeId',
         'universe'
     ],
-    universeIds: ['FOALL$$ALL'],
-    postman: {
-        environmentJSON: postmanJSON
-    }
+    universeIds: ['FOALL$$ALL']
 });
 ```
 

--- a/docs/connectors/morningstar/screeners/investor-preferences.md
+++ b/docs/connectors/morningstar/screeners/investor-preferences.md
@@ -22,6 +22,11 @@ Here is an example of how to use the Investor Preferences connector:
 
 ```js
 const investorPreferencesConnector = new HighchartsConnectors.Morningstar.InvestorPreferencesConnector({
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
+    },
     page: 1,
     pageSize: 20,
     languageId: 'en-GB',
@@ -63,10 +68,7 @@ const investorPreferencesConnector = new HighchartsConnectors.Morningstar.Invest
             }]
         }
     }],
-    universeIds: ['FOALL$$ALL'],
-    postman: {
-        environmentJSON: postmanJSON
-    }
+    universeIds: ['FOALL$$ALL']
 });
 ```
 

--- a/docs/connectors/morningstar/screeners/regulatory-screener.md
+++ b/docs/connectors/morningstar/screeners/regulatory-screener.md
@@ -24,6 +24,11 @@ Here is an example of how to use the Regulatory Screener connector:
 
 ```js
 const screenerConnector = new HighchartsConnectors.Morningstar.InvestmentScreenerConnector({
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
+    },
     page: 1,
     pageSize: 20,
     languageId: 'en-AU',
@@ -43,10 +48,7 @@ const screenerConnector = new HighchartsConnectors.Morningstar.InvestmentScreene
         'EET_SustInv_A8',
     ],
     universeIds: ['FOEUR$$ALL_5791'],
-    sortOrder: 'name asc',
-    postman: {
-        environmentJSON: postmanJSON
-    }
+    sortOrder: 'name asc'
 });
 ```
 

--- a/docs/connectors/morningstar/security-compare.md
+++ b/docs/connectors/morningstar/security-compare.md
@@ -51,8 +51,10 @@ Example usage:
 
 ```js
 const connector = new HighchartsConnectors.Morningstar.SecurityCompareConnector({
-    postman: {
-        environmentJSON: postmanJSON
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
     },
     security: {
         ids: ['F0GBR050DD', 'F00000Q5PZ'],
@@ -70,8 +72,10 @@ For more details, see [Morningstar’s Investment Compare API].
 const ids = ['F0GBR050DD', 'F00000Q5PZ'];
 
 const connector = new HighchartsConnectors.Morningstar.SecurityCompareConnector({
-    postman: {
-        environmentJSON: postmanJSON
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
     },
     security: {
         ids,
@@ -88,10 +92,16 @@ Highcharts.chart('container', {
     series: ids.map(id => ({
         type: 'column',
         name: id,
-        data: connector.dataTables.TrailingPerformance.getRowObjects().map(obj => [
-            obj['Nav_DayEnd_TimePeriod_' + id],
-            obj['Nav_DayEnd_Value_' + id]
-        ])
+        data: connector.dataTables.TrailingPerformance.getRows(
+            void 0,
+            void 0,
+            [
+                // Categories on x-axis
+                'Nav_DayEnd_TimePeriod_' + id,
+                // Values on y-axis
+                'Nav_DayEnd_Value_' + id
+            ]
+        )
     })),
     xAxis: {
         type: 'category'

--- a/docs/connectors/morningstar/security-details.md
+++ b/docs/connectors/morningstar/security-details.md
@@ -51,8 +51,10 @@ Example usage:
 
 ```js
 const securityDetailsConnector = new HighchartsConnectors.Morningstar.SecurityDetailsConnector({
-    postman: {
-        environmentJSON: postmanJSON
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
     },
     security: {
         id: 'F0GBR050DD',
@@ -68,8 +70,10 @@ For more details, see [Morningstar’s Security Details API].
 
 ```js
 const securityDetailsConnector = new HighchartsConnectors.Morningstar.SecurityDetailsConnector({
-    postman: {
-        environmentJSON: postmanJSON
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
     },
     security: {
         id: 'F0GBR050DD',
@@ -87,10 +91,12 @@ Highcharts.chart('container', {
     series: [{
         type: 'column',
         name: 'F0GBR050DD',
-        data: connector.dataTables.TrailingPerformance.getRowObjects().map(obj => [
-            obj.Nav_DayEnd_TimePeriod,
-            obj.Nav_DayEnd_Value
-        ])
+        data: connector.dataTables.TrailingPerformance.getRows(
+            void 0,
+            void 0,
+            // Get X and Y data for the chart:
+            ['Nav_DayEnd_TimePeriod', 'Nav_DayEnd_Value']
+        )
     }],
     xAxis: {
         type: 'category'

--- a/docs/connectors/morningstar/time-series/cumulative-return.md
+++ b/docs/connectors/morningstar/time-series/cumulative-return.md
@@ -17,8 +17,10 @@ the Time Series Connector options.
 
 ```js
 const cumulReturnConnector = new HighchartsConnectors.Morningstar.TimeSeriesConnector({
-    postman: {
-        environmentJSON: postmanJSON
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
     },
     series: {
         type: 'CumulativeReturn'

--- a/docs/connectors/morningstar/time-series/dividend.md
+++ b/docs/connectors/morningstar/time-series/dividend.md
@@ -14,8 +14,10 @@ In order to fetch a dividend time series, specify series type
 
 ```js
 const dividendConnector = new HighchartsConnectors.Morningstar.TimeSeriesConnector({
-    postman: {
-        environmentJSON: postmanJSON
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
     },
     series: {
         type: 'Dividend'

--- a/docs/connectors/morningstar/time-series/growth.md
+++ b/docs/connectors/morningstar/time-series/growth.md
@@ -16,8 +16,10 @@ the Time Series Connector options.
 
 ```js
 const growthConnector = new HighchartsConnectors.Morningstar.TimeSeriesConnector({
-    postman: {
-        environmentJSON: postmanJSON
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
     },
     series: {
         type: 'Growth'

--- a/docs/connectors/morningstar/time-series/ohlcv.md
+++ b/docs/connectors/morningstar/time-series/ohlcv.md
@@ -13,9 +13,11 @@
 
  ```js
  const ohlcvConnector = new HighchartsConnectors.Morningstar.TimeSeriesConnector({
-     postman: {
-         environmentJSON: postmanJSON
-     },
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
+    },
      series: {
          type: 'OHLCV'
      },

--- a/docs/connectors/morningstar/time-series/price.md
+++ b/docs/connectors/morningstar/time-series/price.md
@@ -15,8 +15,10 @@ the Time Series Connector options.
 
 ```js
 const priceConnector = new HighchartsConnectors.Morningstar.TimeSeriesConnector({
-    postman: {
-        environmentJSON: postmanJSON
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
     },
     series: {
         type: 'Price'

--- a/docs/connectors/morningstar/time-series/rating.md
+++ b/docs/connectors/morningstar/time-series/rating.md
@@ -19,8 +19,10 @@ the Time Series Connector options.
 
 ```js
 const ratingConnector = new HighchartsConnectors.Morningstar.TimeSeriesConnector({
-    postman: {
-        environmentJSON: postmanJSON
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
     },
     series: {
         type: 'Rating'

--- a/docs/connectors/morningstar/time-series/return.md
+++ b/docs/connectors/morningstar/time-series/return.md
@@ -14,8 +14,10 @@ In order to fetch a return time series, specify series type
 
 ```js
 const dividendConnector = new HighchartsConnectors.Morningstar.TimeSeriesConnector({
-    postman: {
-        environmentJSON: postmanJSON
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
     },
     series: {
         type: 'Return'

--- a/docs/connectors/morningstar/time-series/rolling-return.md
+++ b/docs/connectors/morningstar/time-series/rolling-return.md
@@ -14,8 +14,10 @@ In order to fetch a rolling return time series, specify series type
 
 ```js
 const dividendConnector = new HighchartsConnectors.Morningstar.TimeSeriesConnector({
-    postman: {
-        environmentJSON: postmanJSON
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
     },
     series: {
         type: 'RollingReturn'

--- a/docs/connectors/morningstar/time-series/time-series.md
+++ b/docs/connectors/morningstar/time-series/time-series.md
@@ -34,8 +34,10 @@ or `currencyId`.
 
 ```js
 const dividendConnector = new HighchartsConnectors.Morningstar.TimeSeriesConnector({
-    postman: {
-        environmentJSON: postmanJSON
+    api: {
+        access: {
+            token: 'your_access_token'
+        }
     },
     series: {
         type: 'Dividend'
@@ -68,8 +70,10 @@ Dashboards.board('container', {
             id: 'time-series',
             type: 'MorningstarTimeSeries',
             options: {
-                postman: {
-                    environmentJSON: postmanJSON
+                api: {
+                    access: {
+                        token: 'your_access_token'
+                    }
                 },
                 series: {
                     type: 'Dividend'


### PR DESCRIPTION
During v2.0 tests found a few bugs in demos. In addition replaced all `postman` options in docs with `api.access.token` (recommended).

What do you think about:

```
data: connector.dataTables.TrailingPerformance.getRows(
            void 0,
            void 0,
            // Get X and Y data for the chart:
            ['Nav_DayEnd_TimePeriod', 'Nav_DayEnd_Value']
        )
```

Alternatively, it can be (`Nav_DayEnd_TimePeriod` and `Nav_DayEnd_Value` are the last columns):
```
keys: ['_', '_', ..., 'x', 'y'],
data: connector.dataTables.TrailingPerformance.getRows()
```

Instead of the mapping (v1 demos):
```js
            data: connector.dataTables.TrailingPerformance.getRowObjects().map(obj => [
                obj.Nav_DayEnd_TimePeriod,
                obj.Nav_DayEnd_Value
            ])
```