### PR TITLE
Fixed wrong region detect, added default US endpoint URL for PAUS connectors.

### DIFF
--- a/src/Shared/MorningstarRegion.ts
+++ b/src/Shared/MorningstarRegion.ts
@@ -33,6 +33,10 @@ export namespace MorningstarRegion {
 
 
     export type Name = ('Americas'|'APAC'|'EMEA');
+    type RegexGroups = {
+        lang: string;
+        region?: string;
+    };
 
 
     /* *
@@ -78,13 +82,20 @@ export namespace MorningstarRegion {
 
 
     export function detect (): Name {
-        const country = window.navigator.language.toUpperCase().match(/-(\w\w)/u);
+        const regex =
+            /^(?<lang>[\w]{2})(?:-(?<region>[\w]{2})(?:-[\w]{2,8})*|-[\w]{3,}(?:-[\w]{2,8})*)?$/u;
+        const match = window.navigator.language.toUpperCase().match(regex);
+
+        if (!match) return 'Americas';
+
+        const { lang, region } = match.groups as RegexGroups;
+        const country = region ?? lang;
 
         if (country) {
-            if (countriesAmericas.includes(country[1])) {
+            if (countriesAmericas.includes(country)) {
                 return 'Americas';
             }
-            if (countriesEMEA.includes(country[1])) {
+            if (countriesEMEA.includes(country)) {
                 return 'EMEA';
             }
             return 'APAC';

--- a/src/Shared/PAUSConnector.ts
+++ b/src/Shared/PAUSConnector.ts
@@ -28,6 +28,7 @@ import MorningstarAPI from './MorningstarAPI';
 import type PAUSOptions from './PAUSOptions';
 import * as External from './External';
 import { PAUSPayload } from './PAUSOptions';
+import MorningstarRegion from './MorningstarRegion';
 
 
 /* *
@@ -83,7 +84,10 @@ export abstract class PAUSConnector extends MorningstarConnector {
 
         const api = this.api = this.api || new MorningstarAPI(this.options.api);
 
-        const fullUrl = new MorningstarURL(`${this.url}?langcult=${this.options.langcult || 'en-US'}`, this.api.baseURL);
+        const fullUrl = new MorningstarURL(
+            `${this.url}?langcult=${this.options.langcult || 'en-US'}`,
+            this.options?.api?.url || MorningstarRegion.baseURLs['Americas']
+        );
         const bodyPayload = this.getPayload();
 
         const response = await api.fetch(fullUrl, {


### PR DESCRIPTION
New regex for region detection based on this list https://gist.github.com/wpsmith/7604842 and official [RFC documentation](https://datatracker.ietf.org/doc/html/rfc5646).

_Internal note:_ Unable to test for correct US URL in PAUS tests, since all tests are setup to hit _emea_ endpoint. Not exactly sure how to approach this one 🤔 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211160184122289