### PR TITLE
Adjusted Performance Correlation Matrix converter to new API changes.

### DIFF
--- a/src/Performance/Converters/CorrelationMatrixConverter.ts
+++ b/src/Performance/Converters/CorrelationMatrixConverter.ts
@@ -73,9 +73,7 @@ export class CorrelationMatrixConverter extends MorningstarConverter {
                 for (const key of Correlations) {
                     const { CorrelatedItemKey, SecurityId, Type } = key;
                     const isPortfolio = Type === 'Portfolio';
-                    const name = isPortfolio ?
-                        TrailingTimePeriod + '_Portfolio' + columnSuffix :
-                        TrailingTimePeriod + `_${SecurityId}` + columnSuffix;
+                    const name = `${TrailingTimePeriod}_${isPortfolio ? 'Portfolio' : SecurityId}${columnSuffix}`;
 
                     let correlationIndex = 0;
 

--- a/src/Performance/Converters/CorrelationMatrixConverter.ts
+++ b/src/Performance/Converters/CorrelationMatrixConverter.ts
@@ -68,22 +68,40 @@ export class CorrelationMatrixConverter extends MorningstarConverter {
                 const { TrailingTimePeriod, Correlations } = correlationMatrixItem;
 
                 let rowIndex = 0;
+                let securityIndex = 0;
 
                 for (const key of Correlations) {
-                    const { CorrelatedItemKey, SecurityId, Id } = key;
-                    const name = TrailingTimePeriod + `_${SecurityId}` + columnSuffix;
+                    const { CorrelatedItemKey, SecurityId, Type } = key;
+                    const isPortfolio = Type === 'Portfolio';
+                    const name = isPortfolio ?
+                        TrailingTimePeriod + '_Portfolio' + columnSuffix :
+                        TrailingTimePeriod + `_${SecurityId}` + columnSuffix;
+
+                    let correlationIndex = 0;
 
                     for (let i = 0; i < CorrelatedItemKey.length; i++) {
+                        if (CorrelatedItemKey[i].Type === 'Portfolio') {
+                            continue;
+                        }
                         const value = CorrelatedItemKey[i].Value;
-                        table.setCell(name, i, value);
+                        table.setCell(name, correlationIndex, value);
 
-                        if (i <= Id - 1) {
-                            table.setCell('x' + columnSuffix, rowIndex, i);
-                            table.setCell('y' + columnSuffix, rowIndex, Id - 1);
+                        // Fill x,y coords and the heatmap value for the lower
+                        // triangle cells only, excluding Portfolio
+                        if (!isPortfolio && correlationIndex <= securityIndex) {
+                            table.setCell('x' + columnSuffix, rowIndex, correlationIndex);
+                            table.setCell('y' + columnSuffix, rowIndex, securityIndex);
                             table.setCell(TrailingTimePeriod + columnSuffix, rowIndex, value);
 
                             rowIndex++;
                         }
+
+                        correlationIndex++;
+                    }
+
+                    // Increment index only for securities, not Portfolio
+                    if (!isPortfolio) {
+                        securityIndex++;
                     }
                 }
             }

--- a/src/Performance/PerformanceOptions.ts
+++ b/src/Performance/PerformanceOptions.ts
@@ -58,7 +58,7 @@ export interface PerformanceRequestPayload extends PAUSPayload {
 }
 
 export interface PerformanceRequestSettings extends RequestSettings {
-    includePortfolioCorrelationMatrix?: boolean;
+    includePortfolioInCorrelationMatrix?: boolean;
     initialValue?: number;
     analysisDateTimePeriod?: string;
     portfolioPerformanceStartDate?: string;

--- a/src/Performance/PerformanceOptions.ts
+++ b/src/Performance/PerformanceOptions.ts
@@ -58,6 +58,10 @@ export interface PerformanceRequestPayload extends PAUSPayload {
 }
 
 export interface PerformanceRequestSettings extends RequestSettings {
+    /**
+     * @deprecated Use `includePortfolioInCorrelationMatrix` instead.
+     */
+    includePortfolioCorrelationMatrix?: boolean;
     includePortfolioInCorrelationMatrix?: boolean;
     initialValue?: number;
     analysisDateTimePeriod?: string;

--- a/tests/Performance/CorrelationMatrix.test.ts
+++ b/tests/Performance/CorrelationMatrix.test.ts
@@ -9,10 +9,10 @@ export async function PerformanceCorrelationMatrixLoad (
         id: '',
         type: '',
         api,
-        viewId: 'All',
+        viewId: 'CorrelationMatrix',
         configId: 'Hypothetical',
         requestSettings: {
-            includePortfolioCorrelationMatrix: true,
+            includePortfolioInCorrelationMatrix: true,
             outputCurrency: 'USD',
             assetClassGroupConfigs: {
                 assetClassGroupConfig: [
@@ -64,12 +64,15 @@ export async function PerformanceCorrelationMatrixLoad (
         'Year10',
         'Year10_FOUSA04BCR',
         'Year10_FOUSA05H5F',
+        'Year10_Portfolio',
         'Year3',
         'Year3_FOUSA04BCR',
         'Year3_FOUSA05H5F',
+        'Year3_Portfolio',
         'Year5',
         'Year5_FOUSA04BCR',
         'Year5_FOUSA05H5F',
+        'Year5_Portfolio',
         'x',
         'y'
     ];


### PR DESCRIPTION
Adjusted the Performance Correlation Matrix converter to handle Portfolio entries alongside the updated Morningstar API.

Key points for this change:
- The JSON response now includes Portfolio values, which required adapting converter logic in order to preserve ease of creating heatmap demos along with showing new columns for Portfolio records.
- `includePortfolioCorrelationMatrix` has been renamed to `includePortfolioInCorrelationMatrix`
- The correlation matrix is returned only when the `viewId` is set to `CorrelationMatrix`.
- It is now possible via API to return a `CrossPortfolioCorrelation` (not part of this PR). It is not yet supported in Performance Connector, however shouldn't be hard to add by simply checking for different path (since it shares the same format inside).
- According to OpenAPI, the Benchmark can be skipped completely in the Portfolios array, only valid entries of Holdings are necessary for the payload.
<img width="753" height="188" alt="image" src="https://github.com/user-attachments/assets/8aaff81a-ae08-4e1c-a08d-6da0d26ebcdc" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215629608352660